### PR TITLE
[Bug] Fix App Requiring Users Re-Authenticate After Successful Login (SC-190943)

### DIFF
--- a/.github/workflows/subworkflow-build.yml
+++ b/.github/workflows/subworkflow-build.yml
@@ -49,7 +49,8 @@ jobs:
           if [ -n "${{ github.event.pull_request.number }}" ]; then
             # Regular PR case
             echo "PR number found: ${{ github.event.pull_request.number }}"
-            labels=$(jq -r '[.[] | .name] | join(",")' <<< '${{ toJson(github.event.pull_request.labels) }}')
+            json_labels='${{ toJson(github.event.pull_request.labels) }}'
+            labels=$(echo "$json_labels" | jq -r '[.[] | .name] | join(",")')
           else
             # Merge queue case - find PR by head ref
             echo "No PR number found, checking for merge group"

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,7 @@
       "isRequired": false,
       "isBackendOnly": false,
       "default": false,
-      "condition": "settings.use_advanced_connect == true",
+      "condition": "settings.use_advanced_connect != false",
       "order": 2
     },
     "company_id": {
@@ -48,7 +48,7 @@
       "type": "string",
       "isRequired": false,
       "isBackendOnly": false,
-      "condition": "settings.use_advanced_connect == true",
+      "condition": "settings.use_advanced_connect != false",
       "order": 4
     },
     "client_secret": {
@@ -56,7 +56,7 @@
       "type": "string",
       "isRequired": false,
       "isBackendOnly": true,
-      "condition": "settings.use_advanced_connect == true",
+      "condition": "settings.use_advanced_connect != false",
       "order": 5
     },
     "callback_url": {
@@ -65,7 +65,7 @@
       "options": { "entrypoint": "#/admin/callback", "height": "80px" },
       "isRequired": false,
       "isBackendOnly": false,
-      "condition": "settings.use_advanced_connect == true",
+      "condition": "settings.use_advanced_connect != false",
       "order": 6
     }
   },

--- a/src/api/quickbooks/baseRequest/baseRequest.ts
+++ b/src/api/quickbooks/baseRequest/baseRequest.ts
@@ -40,7 +40,7 @@ export default async function baseRequest<T>(client: IDeskproClient, reqProps: R
         method,
         body: data,
         headers: {
-            "Authorization": `Bearer ${placeholders.OAUTH2_ACCESS_TOKEN_PATH}`,
+            "Authorization": `Bearer [user[${placeholders.OAUTH2_ACCESS_TOKEN_PATH}]]`,
             "Accept": "application/json",
             ...customHeaders,
             ...(data ? { "Content-Type": "application/json" } : {}),

--- a/src/pages/loading/LoadingPage.tsx
+++ b/src/pages/loading/LoadingPage.tsx
@@ -21,21 +21,25 @@ export default function LoadingPage() {
         clearElements();
         registerElement('refresh', { type: 'refresh_button' });
     }, []);
+    const isUsingGlobalProxy = context?.settings.use_advanced_connect === false
+    const isUsingSandbox = context?.settings.use_sandbox === true;
+    const companyId = context?.settings.company_id
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     useInitialisedDeskproAppClient(async client => {
         client.setTitle('QuickBooks');
 
-        if (!context || !user) {
+        if (!companyId || !user) {
             return;
         };
 
-        const isUsingSandbox = context.settings.use_sandbox;
 
         await client.setUserState(placeholders.IS_USING_SANDBOX, isUsingSandbox);
+        await client.setUserState("isUsingGlobalProxy", isUsingGlobalProxy)
+
 
         try {
-            const company = await getCompanyInfo(client, context.settings.company_id);
+            const company = await getCompanyInfo(client, companyId);
 
             if (company) {
                 setIsAuthenticated(true);
@@ -46,7 +50,7 @@ export default function LoadingPage() {
         } finally {
             setIsFetchingAuth(false);
         };
-    }, [context, context?.settings]);
+    }, [isUsingSandbox, companyId, isUsingGlobalProxy]);
 
 
     if (!client || !user || isFetchingAuth) {

--- a/src/pages/login/useLogin.ts
+++ b/src/pages/login/useLogin.ts
@@ -39,7 +39,9 @@ export default function useLogin(): UseLoginResult {
 
         const clientID = context.settings.client_id;
 
-        if (mode === 'local' && typeof clientID !== 'string') {
+        if (mode === 'local' && (typeof clientID !== 'string' || clientID.trim() === "")) {
+            // Local mode requires a clientId.
+            setError("No client id was provided while setting up the app, a client id is required when using advanced connect.")
             return;
         };
 
@@ -72,7 +74,7 @@ export default function useLogin(): UseLoginResult {
 
         setAuthUrl(oauth2Response.authorizationUrl)
         setOAuth2Context(oauth2Response)
-    }, [context, setAuthUrl]);
+    }, [context?.settings, setAuthUrl, mode, user]);
 
 
     useInitialisedDeskproAppClient((client) => {
@@ -111,8 +113,8 @@ export default function useLogin(): UseLoginResult {
                                     throw new Error(errorMessage)
                                 }
                                 break
-                                case "SERVICE": 
-                                if(fault.error?.[0].code  === "3100"){
+                            case "SERVICE":
+                                if (fault.error?.[0].code === "3100") {
                                     throw new Error(`Error authenticating user: Ensure the QuickBooks app is setup to use ${isUsingSandbox ? "sandbox" : "production"} accounts.`)
 
                                 }

--- a/src/pages/login/useLogin.ts
+++ b/src/pages/login/useLogin.ts
@@ -116,6 +116,7 @@ export default function useLogin(): UseLoginResult {
                                     throw new Error(`Error authenticating user: Ensure the QuickBooks app is setup to use ${isUsingSandbox ? "sandbox" : "production"} accounts.`)
 
                                 }
+                                break
                         }
                     };
 

--- a/src/pages/login/useLogin.ts
+++ b/src/pages/login/useLogin.ts
@@ -111,6 +111,11 @@ export default function useLogin(): UseLoginResult {
                                     throw new Error(errorMessage)
                                 }
                                 break
+                                case "SERVICE": 
+                                if(fault.error?.[0].code  === "3100"){
+                                    throw new Error(`Error authenticating user: Ensure the QuickBooks app is setup to use ${isUsingSandbox ? "sandbox" : "production"} accounts.`)
+
+                                }
                         }
                     };
 

--- a/src/types/quickbooks.ts
+++ b/src/types/quickbooks.ts
@@ -20,7 +20,7 @@ export interface QuickBooksErrorObject {
 export interface QuickBooksFault {
     error?: Pick<QuickBooksErrorObject, "message" | "code" | "detail" | "element" | "statusCode">[]
     Error?: Pick<QuickBooksErrorObject, "Message" | "Detail" | "code">[]
-    type: "AuthorizationFault" | "AUTHENTICATION" 
+    type: "AuthorizationFault" | "AUTHENTICATION" | "SERVICE" | "AuthenticationFault"
 }
 
 export interface QuickBooksFaultError {


### PR DESCRIPTION
## Description
This PR addresses the following:
- Fixes a bug in  the `baseRequest` function resulting in the initial request failing and always requiring a refresh to succeed.
- Improves the error message being shown to the user when on the login page with custom messages for multiple scenarios.
- Prevents refreshing the access token when using the global proxy ("Quick Connect").
- Fix conditional rendering logic in `manifest.json`

## Limitations
When installed with quick connect users will not be able to refresh their access tokens so they would be required to re-authenticate more frequently.

## Evidence
### When a user attempts logging in with a sandbox account but the app is setup with the sandbox flag is turned off.
<img width="193" alt="image" src="https://github.com/user-attachments/assets/3965d2c9-0c78-443d-b9d7-2b0f243d3364" />

### When a user attempts logging in with a sandbox account but the app is setup with Quick Connect.
<img width="199" alt="image" src="https://github.com/user-attachments/assets/d354bf8f-fb8b-4446-b9c0-6684a02e8f1f" />

### Logging in with a sandbox account.


https://github.com/user-attachments/assets/c1f3e522-267c-4e01-b922-69c9ef149099

### When a user installs the app with advanced connect but doesn't include a client id.

<img width="127" alt="image" src="https://github.com/user-attachments/assets/e5c2c1f7-1452-41e4-940e-55163f733cdd" />