### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -84,12 +84,34 @@
       {
         "url": "https://oauth.platform.intuit.com/oauth2/v1/.*",
         "methods": ["POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "client_id": {
+            "header": ["Authorization"]
+          },
+          "client_secret": {
+            "header": ["Authorization"]
+          },
+          "integration_key": {
+            "header": ["Authorization"]
+          },
+          "secret_key": {
+            "header": ["Authorization"]
+          }
+        }
       },
       {
         "url": "https://developer.api.intuit.com/v2/oauth2/tokens/revoke",
         "methods": ["POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "client_id": {
+            "header": ["Authorization"]
+          },
+          "client_secret": {
+            "header": ["Authorization"]
+          }
+        }
       }
     ]
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ export const placeholders = {
     OAUTH2_ACCESS_TOKEN_PATH: 'oauth2/access_token',
     OAUTH2_REFRESH_TOKEN_PATH: 'oauth2/refresh_token',
     IS_USING_SANDBOX: 'is_using_sandbox',
-};
+} as const;
 
 export const GLOBAL_CLIENT_ID = 'ABvWsXjB1yre80UrAXj7uDaWUOWPiW7CZ04t0BJgM75UJZYxJ8';
 


### PR DESCRIPTION
This pull request introduces improvements to the way sensitive credentials are injected into API requests and refines type safety in the constants file. The most significant updates are in the API manifest configuration, enabling dynamic injection of credentials into request headers for specific endpoints, and a minor enhancement to the constants definition for better type inference.

**API Credential Injection Enhancements:**

* Added a `settingsInjection` configuration to relevant endpoints in `manifest.json`, allowing `client_id`, `client_secret`, `integration_key`, and `secret_key` to be dynamically injected into the `Authorization` header for authentication requests.
* Applied the same `settingsInjection` logic to the token revocation endpoint, supporting dynamic header injection for `client_id` and `client_secret`.

**Type Safety and Constants Improvements:**

* Updated the `placeholders` object in `src/constants.ts` to use `as const`, improving type safety and ensuring the object’s values are treated as immutable literals.

## Summary by Sourcery

Limit where token-related settings can be injected by adding a `settingsInjection` configuration to OAuth token endpoints and strengthen constant definitions for safer type inference

New Features:
- Restrict token placeholder injections to specific OAuth manifest endpoints using `settingsInjection`
- Enable dynamic injection of client credentials into the `Authorization` header for access token and token revocation URLs

Enhancements:
- Improve type safety of placeholders by marking the `placeholders` object as immutable with `as const`